### PR TITLE
Use thumbprint instead of friendly name for certificate labels.

### DIFF
--- a/src/p11-capi.c
+++ b/src/p11-capi.c
@@ -288,6 +288,42 @@ p11c_return_string(CK_ATTRIBUTE_PTR attr, WCHAR* string)
 }
 
 CK_RV
+p11c_return_data_as_hex_string(CK_ATTRIBUTE_PTR attr, CK_VOID_PTR data, CK_ULONG length)
+{
+	CK_ULONG i;
+
+	/* Allow 2 characters per byte. PKCS#11 strings are not null-terminated. */
+	const CK_ULONG string_length = length * 2;
+
+	/* Just asking for the length */
+	if(!attr->pValue)
+	{
+		attr->ulValueLen = string_length;
+		return CKR_OK;
+	}
+
+	/* Buffer is too short */
+	if(attr->ulValueLen < string_length)
+	{
+		attr->ulValueLen = string_length;
+		return CKR_BUFFER_TOO_SMALL;
+	}
+
+	/* Convert to hex string, discarding null terminators */
+	for(i = 0; i < length; ++i)
+	{
+		unsigned char* bytes = data;
+		unsigned char* value = attr->pValue;
+		char buf[3];
+
+		snprintf(buf, sizeof(buf), "%02x", bytes[i]);
+		memcpy(&value[i * 2], buf, sizeof(buf) - 1);
+	}
+
+	return CKR_OK;
+}
+
+CK_RV
 p11c_return_dword_as_bytes(CK_ATTRIBUTE_PTR attr, DWORD value)
 {
 	int i;

--- a/src/p11-capi.h
+++ b/src/p11-capi.h
@@ -108,6 +108,9 @@ CK_RV       p11c_return_data_raw          (CK_VOID_PTR output, CK_ULONG_PTR n_ou
 CK_RV       p11c_return_string            (CK_ATTRIBUTE_PTR attr, 
                                            WCHAR* string);
 
+CK_RV       p11c_return_data_as_hex_string(CK_ATTRIBUTE_PTR attr,
+                                           CK_VOID_PTR data, CK_ULONG length);
+
 CK_RV       p11c_return_dword_as_bytes    (CK_ATTRIBUTE_PTR attr, 
                                            DWORD value);
 


### PR DESCRIPTION
Using the friendly name property (CERT_FRIENDLY_NAME_PROP_ID) as the CKA_LABEL
attribute value for a certificate can be problematic, as not all certificates
have a value for this property. This has been seen to cause problems with NSS,
where multiple certificates without friendly names were assigned the same
nickname. This resulted in a browser only being able to access one of the
certificates.

This fix updates p11c_cert_certificate_get_bytes() to report the certificate's
thumbprint instead (provided by the CERT_HASH_PROP_ID property). Thumbprints
are commonly used to identify certificates on Windows systems, and can be
calculated for any certificate (as they are simply a hash).

Signed-off-by: Simon Haggett <simon.haggett@gmail.com>